### PR TITLE
Shell scripts compatibility issue and icon for ted2_macos.app

### DIFF
--- a/scripts/makedocs.sh
+++ b/scripts/makedocs.sh
@@ -1,5 +1,5 @@
 
-source common.sh
+. ./common.sh
 
 $mx2cc makedocs
 

--- a/scripts/rebuildmods.sh
+++ b/scripts/rebuildmods.sh
@@ -1,5 +1,5 @@
 
-source common.sh
+. ./common.sh
 
 echo ""
 echo "***** Rebuilding modules *****"

--- a/scripts/rebuildmx2cc.sh
+++ b/scripts/rebuildmx2cc.sh
@@ -1,5 +1,5 @@
 
-source common.sh
+. ./common.sh
 
 echo ""
 echo "***** Rebuilding mx2cc *****"

--- a/scripts/rebuildted2go.sh
+++ b/scripts/rebuildted2go.sh
@@ -35,6 +35,9 @@ else
 
 	rm -r -f $ted2
 	cp -R ./ted2go.products/macos/ted2.app $ted2
+
+	cp ../src/ted2go/info.plist "$ted2/Contents"
+	cp ../src/launcher/Monkey2logo.icns "$ted2/Contents/Resources"
 	
 	rm -r -f "$launcher"
 	cp -R ./launcher.products/macos/Launcher.app "$launcher"

--- a/scripts/rebuildted2go.sh
+++ b/scripts/rebuildted2go.sh
@@ -1,5 +1,5 @@
 
-source common.sh
+. ./common.sh
 
 echo ""
 echo "***** Rebuilding ted2go *****"

--- a/scripts/updatemods.sh
+++ b/scripts/updatemods.sh
@@ -1,5 +1,5 @@
 
-source common.sh
+. ./common.sh
 
 echo ""
 echo "***** Updating modules *****"

--- a/scripts/updatemx2cc.sh
+++ b/scripts/updatemx2cc.sh
@@ -1,5 +1,5 @@
 
-source common.sh
+. ./common.sh
 
 echo ""
 echo "***** Updating mx2cc *****"

--- a/scripts/updateted2go-github.sh
+++ b/scripts/updateted2go-github.sh
@@ -35,6 +35,9 @@ else
 
 	rm -r -f $ted2
 	cp -R ./ted2go-github.products/macos/ted2.app $ted2
+
+	cp ../src/ted2go/info.plist "$ted2/Contents"
+	cp ../src/launcher/Monkey2logo.icns "$ted2/Contents/Resources"
 	
 	rm -r -f "$launcher"
 	cp -R ./launcher.products/macos/Launcher.app "$launcher"

--- a/scripts/updateted2go-github.sh
+++ b/scripts/updateted2go-github.sh
@@ -1,5 +1,5 @@
 
-source common.sh
+. ./common.sh
 
 echo ""
 echo "***** Updating ted2go *****"

--- a/scripts/updateted2go.sh
+++ b/scripts/updateted2go.sh
@@ -35,6 +35,9 @@ else
 
 	rm -r -f $ted2
 	cp -R ./ted2go.products/macos/ted2.app $ted2
+
+	cp ../src/ted2go/info.plist "$ted2/Contents"
+	cp ../src/launcher/Monkey2logo.icns "$ted2/Contents/Resources"
 	
 	rm -r -f "$launcher"
 	cp -R ./launcher.products/macos/Launcher.app "$launcher"

--- a/scripts/updateted2go.sh
+++ b/scripts/updateted2go.sh
@@ -1,5 +1,5 @@
 
-source common.sh
+. ./common.sh
 
 echo ""
 echo "***** Updating ted2go *****"

--- a/src/ted2go/info.plist
+++ b/src/ted2go/info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>Ted2go</string>
+	<key>CFBundleIconFile</key>
+	<string>Monkey2logo</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+</dict>
+</plist>

--- a/src/ted2go/info.plist
+++ b/src/ted2go/info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleExecutable</key>
-	<string>Ted2go</string>
+	<string>ted2</string>
 	<key>CFBundleIconFile</key>
 	<string>Monkey2logo</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
    1. macOS only: Added info.plist and Monkey2logo.icns to Ted2go.app, so the icon appears in the macOS dock. Delete bin/ted2_macos.app and run rebuildted2go.sh to apply.

2. Changed all "source common.sh" in scripts to ". ./common.sh" for greatest compatibility with different shells. For example Ubuntu uses 'dash' instead of 'bash' by default and some shells do not know the newer 'source' command, resulting in a script error at the 'source' command.
